### PR TITLE
docs: add client MFA enrollment endpoint and correct API error format

### DIFF
--- a/docs/contributing/backend/how-to-design-an-api-endpoint.md
+++ b/docs/contributing/backend/how-to-design-an-api-endpoint.md
@@ -63,11 +63,11 @@ POST is used for actions that do not map cleanly to CRUD operations (e.g., `disa
 | 200 OK | Successful GET, PATCH, action POST, DELETE | Return the resource or confirmation |
 | 201 Created | Successful resource creation (POST) | Return the created resource |
 | 400 Bad Request | Invalid input, business rule violation | Default for all `BusinessException` |
-| 401 Unauthorized | Missing or invalid authentication token | `{"error": "unauthorized", ...}` |
-| 403 Forbidden | Valid token but insufficient scope | `{"error": "forbidden", ...}` |
-| 404 Not Found | Resource does not exist | `{"error": "not_found", ...}` |
-| 409 Conflict | Resource already exists or state conflict | `{"error": "conflict", ...}` |
-| 500 Internal Server Error | Unexpected server error | `{"error": "internal_server_error", ...}` |
+| 401 Unauthorized | Missing or invalid authentication token | `{"error_code": "unauthorized", ...}` |
+| 403 Forbidden | Valid token but insufficient scope | `{"error_code": "forbidden", ...}` |
+| 404 Not Found | Resource does not exist | `{"error_code": "not_found", ...}` |
+| 409 Conflict | Resource already exists or state conflict | `{"error_code": "conflict", ...}` |
+| 500 Internal Server Error | Unexpected server error | `{"error_code": "internal_server_error", ...}` |
 
 DELETE operations return `200` with a confirmation body so the caller can verify which resource was affected:
 
@@ -198,31 +198,41 @@ GET /api/v1/admin/users?sort=created_at&order=desc
 
 ## Error responses
 
-All errors follow a consistent format:
+All errors are serialized as an `ErrorResource` with a consistent structure:
 
 ```json
 {
-  "error": "<error_code>",
-  "error_description": "<human-readable description>"
+  "status": 404,
+  "error_code": "<error_code>",
+  "description": "<user-facing message>",
+  "details": "<technical message for developers>",
+  "properties": null
 }
 ```
 
-- `error`: machine-readable code (lowercase, underscores)
-- `error_description`: human-readable message for debugging
+- `status`: HTTP status code of the response
+- `error_code`: stable, machine-readable code identifying the error (the exception's `detailsId`)
+- `description`: user-facing message, safe to display to the end-user and may guide recovery (the exception's
+  `descriptionId`)
+- `details`: technical message to help developers troubleshoot. Only populated when the `print-details-in-error`
+  feature is enabled — otherwise `null`, so internals are never leaked in production
+- `properties`: list of per-property validation errors (each with a `path` and a `description`), or `null`
 
 Authentication and authorization errors use standardized codes:
 
 ```json
 {
-  "error": "unauthorized",
-  "error_description": "Missing or invalid access token."
+  "status": 401,
+  "error_code": "unauthorized",
+  "description": "The access to this resource is protected. Please authenticate before retrying."
 }
 ```
 
 ```json
 {
-  "error": "forbidden",
-  "error_description": "The access token does not include the required scope: admin:users:read"
+  "status": 403,
+  "error_code": "forbidden",
+  "description": "The access token does not include the required scope to access this resource."
 }
 ```
 
@@ -231,8 +241,8 @@ Business errors follow the structured error code pattern defined in
 `descriptionId`, and the distinction between recoverable and unrecoverable exceptions.
 
 ::: warning
-Never expose internal stack traces or implementation details in error responses. The `error_description` should help
-troubleshoot without revealing system internals.
+Never expose internal stack traces or implementation details in error responses. The `details` message is gated behind
+the `print-details-in-error` feature, and neither `description` nor `details` should reveal system internals.
 :::
 
 ## Authentication

--- a/docs/functional/client.md
+++ b/docs/functional/client.md
@@ -33,3 +33,41 @@ Each client must be registered in SympAuthy before it can authenticate users. Re
 - **allowed redirect URIs**: The list of URIs the client is allowed to redirect end-users to after authentication. At least one URI must be configured.
 
 Refer to the [configuration](/technical/configuration/client) section for the full list of options and an example.
+
+## What a client can do
+
+Beyond delegating sign-in, a client can act on the users of its [audience](/functional/audience) through the
+[Client API](/technical/api/client) — a set of endpoints the client calls as itself, authenticated with the
+[client credentials grant](/functional/authentication#service-account-authentication) and gated by
+[client scopes](/functional/scope#client-scope). What a given client is allowed to do depends on the scopes it has been
+[granted](/functional/client_authorization):
+
+- **Look up its users** — list the end-users who have [consented](/functional/consent) to its audience and read their
+  identity information. Requires `users:read`.
+- **Read and write claims** — read the [claims](/functional/claims) it is authorized to see and update the ones it is
+  authorized to modify, according to each claim's access control list. Requires `users:claims:read` /
+  `users:claims:write`.
+- **Manage invitations** — create, list, and revoke [invitations](/functional/invitation) for audiences where open
+  sign-up is disabled. Requires `invitations:read` / `invitations:write`.
+- **Start MFA enrollment on demand** — let a signed-in user add a second factor from within the application
+  (see [below](#enrolling-mfa-on-demand)). Requires `users:mfa:write`.
+
+For the request and response details of every operation, see the [Client API](/technical/api/client) reference.
+
+### Enrolling MFA on demand
+
+Normally an end-user enrolls in [multi-factor authentication](/functional/authentication#multi-factor-authentication-mfa)
+during sign-in — the first time they authenticate after MFA is enabled. A client can also let an **already-signed-in**
+user enroll a second factor **on their own initiative** — for example, from an account-settings or security screen —
+without sending them through a full sign-in.
+
+The client asks SympAuthy to start an enrollment on behalf of one of its users and gets back a URL to send that user
+to. The user goes through the same enrollment steps as during sign-in — choosing a method, then setting up TOTP — and
+once finished is redirected back to the application. An enrollment started this way cannot be skipped.
+
+Because the action is performed for a specific user, the client identifies **both itself and the user** when making the
+request. The address the user is returned to is restricted to the client's registered redirect URIs, so users can only
+ever be sent back to the application they came from.
+
+This is exposed through the [Start MFA Enrollment](/technical/api/client#multi-factor-authentication-mfa) endpoint of
+the Client API.

--- a/docs/functional/scope.md
+++ b/docs/functional/scope.md
@@ -100,6 +100,8 @@ Client scopes are defined by SympAuthy and protect operations of the
 | `users:read`         | List users with consented scopes                     |
 | `users:claims:read`  | Read claims the client is authorized to access       |
 | `users:claims:write` | Write claims the client is authorized to modify      |
+| `users:mfa:read`     | Read a user's MFA enrollment status (reserved for future use) |
+| `users:mfa:write`    | Start MFA enrollment for a signed-in user            |
 
 See [Client Authorization](/functional/client_authorization) for details on client scope granting rules.
 

--- a/docs/technical/api/admin.md
+++ b/docs/technical/api/admin.md
@@ -116,28 +116,24 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 Each Admin API endpoint requires a specific admin scope. The access token must include the scope required by the
 endpoint being called.
 
-- If the token is missing or invalid: **401 Unauthorized**
-- If the token is valid but lacks the required scope: **403 Forbidden**
-
-**401 Response Example**:
-
-```json
-{
-  "error": "unauthorized",
-  "error_description": "Missing or invalid access token."
-}
-```
-
-**403 Response Example**:
-
-```json
-{
-  "error": "forbidden",
-  "error_description": "The access token does not include the required scope: admin:users:read"
-}
-```
+- If the token is missing or invalid: **401 Unauthorized** (`unauthorized`)
+- If the token is valid but lacks the required scope: **403 Forbidden** (`forbidden`)
 
 The required scope for each endpoint is documented in the [Endpoints](#endpoints) section below.
+
+### Error format
+
+When a request fails, the API responds with a JSON error object containing the HTTP `status`, a stable
+machine-readable `error_code`, a user-facing `description`, and — only when the `print-details-in-error` feature is
+enabled on the server — a technical `details` message. Each failure case in this page is listed by its `error_code`
+and `description`.
+
+The following errors may be returned by any endpoint:
+
+| Error code     | Description                                                                    |
+|----------------|--------------------------------------------------------------------------------|
+| `unauthorized` | The access to this resource is protected. Please authenticate before retrying. |
+| `forbidden`    | The access token does not include the required scope to access this resource.  |
 
 ## Endpoints
 
@@ -250,14 +246,11 @@ in responses. Requires the `admin:config:read` scope.
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No client found with id: my-app"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -551,14 +544,11 @@ Endpoints for viewing configured [audiences](/functional/audience). Since audien
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No audience found with id: my-app"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -695,18 +685,15 @@ filtering.
 
 **Errors**:
 
-Returns **400 Bad Request** with error code `invalid_claim` when:
+Returns **400 Bad Request** with error code `user.search.invalid_claim` when:
 
 - `claims` contains a disabled or unknown claim ID
 - `sort` references a disabled or unknown claim ID
 - A claim filter query parameter references a disabled or unknown claim ID
 
-```json
-{
-  "error": "invalid_claim",
-  "error_description": "Unknown or disabled claim: department"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `user.search.invalid_claim` | The claim `{claim}` is not recognized or is currently disabled. Please check the available claims and try again. |
 
 **Use Cases**:
 
@@ -1178,14 +1165,11 @@ Endpoints for viewing and managing the links between end-user accounts and exter
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No user found with id: 550e8400-e29b-41d4-a716-446655440000"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -1234,14 +1218,11 @@ link exists for the user and provider pair.
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No provider link found for user 550e8400-e29b-41d4-a716-446655440000 and provider: discord"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -1583,14 +1564,11 @@ the `user_id` and `used_at` fields.
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No invitation found with id: a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -1639,14 +1617,11 @@ and permanent.
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No invitation found with id: a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Use Cases**:
 

--- a/docs/technical/api/client.md
+++ b/docs/technical/api/client.md
@@ -18,6 +18,8 @@ are granted.
 | `users:read`         | List users with consented scopes                         |
 | `users:claims:read`  | Read claims the client is authorized to access           |
 | `users:claims:write` | Write claims the client is authorized to modify          |
+| `users:mfa:read`     | *(Reserved)* Read a user's MFA enrollment status — no endpoint consumes it yet |
+| `users:mfa:write`    | Start [MFA enrollment](#multi-factor-authentication-mfa) for a signed-in user |
 
 ## Authentication
 
@@ -69,28 +71,24 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 Each Client API endpoint requires a specific client scope. The access token must include the scope required by the
 endpoint being called.
 
-- If the token is missing or invalid: **401 Unauthorized**
-- If the token is valid but lacks the required scope: **403 Forbidden**
-
-**401 Response Example**:
-
-```json
-{
-  "error": "unauthorized",
-  "error_description": "Missing or invalid access token."
-}
-```
-
-**403 Response Example**:
-
-```json
-{
-  "error": "forbidden",
-  "error_description": "The access token does not include the required scope: users:read"
-}
-```
+- If the token is missing or invalid: **401 Unauthorized** (`unauthorized`)
+- If the token is valid but lacks the required scope: **403 Forbidden** (`forbidden`)
 
 The required scope for each endpoint is documented in the [Endpoints](#endpoints) section below.
+
+### Error format
+
+When a request fails, the API responds with a JSON error object containing the HTTP `status`, a stable
+machine-readable `error_code`, a user-facing `description`, and — only when the `print-details-in-error` feature is
+enabled on the server — a technical `details` message. Each failure case in this page is listed by its `error_code`
+and `description`.
+
+The following errors may be returned by any endpoint:
+
+| Error code     | Description                                                                    |
+|----------------|--------------------------------------------------------------------------------|
+| `unauthorized` | The access to this resource is protected. Please authenticate before retrying. |
+| `forbidden`    | The access token does not include the required scope to access this resource.  |
 
 ## Endpoints
 
@@ -167,6 +165,12 @@ Endpoints for listing users and viewing their authorization status. Requires the
 }
 ```
 
+**Errors**:
+
+| Error code | Description |
+|------------|-------------|
+| `client.subject_without_provider` | The `subject` query parameter requires a `provider_id` to be specified. |
+
 **Properties**:
 
 - `users`: Array of user consent records
@@ -232,14 +236,11 @@ Endpoints for listing users and viewing their authorization status. Requires the
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No user found with id: 550e8400-e29b-41d4-a716-446655440000"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -302,14 +303,11 @@ read based on each claim's [ACL](/technical/configuration/claim#claims-id-acl).
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No user found with id: 550e8400-e29b-41d4-a716-446655440000"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -385,23 +383,12 @@ claim's [ACL](/technical/configuration/claim#claims-id-acl) can be modified thro
 }
 ```
 
-`400 Bad Request`:
+**Errors**:
 
-```json
-{
-  "error": "invalid_claim",
-  "error_description": "The claim 'email' cannot be modified by the client. Either the claim does not exist or the client does not hold the required scopes."
-}
-```
-
-`404 Not Found`:
-
-```json
-{
-  "error": "not_found",
-  "error_description": "No user found with id: 550e8400-e29b-41d4-a716-446655440000"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `client.invalid_claim` | The claim `{claim}` cannot be modified by the client. Either the claim does not exist or the client does not hold the required scopes. |
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -422,6 +409,100 @@ claim's [ACL](/technical/configuration/claim#claims-id-acl) can be modified thro
 - Tag users with custom attributes (roles, departments, etc.)
 - Maintain additional user information beyond OpenID Connect claims
 - Update user attributes from external systems
+
+---
+
+### Multi-Factor Authentication (MFA)
+
+Endpoint for starting [multi-factor authentication](/functional/authentication#multi-factor-authentication-mfa)
+enrollment for a signed-in end-user on demand — outside of a sign-in flow. This lets an application offer MFA
+enrollment from, for example, an account-settings or security screen. Requires the `users:mfa:write` scope.
+
+#### Start MFA Enrollment
+
+**Path**: `/api/v1/client/mfa/enrollment`
+
+**Method**: POST
+
+**Authentication**: Bearer token with `users:mfa:write` scope, **plus** the end-user's access token in the request
+body (see **Dual authentication** below)
+
+**Purpose**: Starts a standalone MFA enrollment [interactive flow](/functional/interactive_flow) for an
+already-signed-in end-user and returns a URL to send them to. When the user completes enrollment, they are redirected
+to the `return_uri` supplied by the client. Unlike enrollment offered during sign-in, a standalone enrollment started
+through this endpoint cannot be skipped.
+
+**Dual authentication**: This endpoint acts on behalf of an end-user, so it identifies **two** parties and requires
+**two** credentials:
+
+1. **The client** — authenticates with its client-credentials Bearer token, like every other Client API endpoint, and
+   must hold the `users:mfa:write` scope.
+2. **The end-user** — identified by their own access token, passed in the request body as `access_token`. The server
+   validates this token and derives the user to enroll from it.
+
+The end-user's access token must have been **issued to the calling client**: a client cannot start enrollment using a
+token minted for another client. It must also be a user token — a client-credentials token, which has no associated
+user, is rejected.
+
+**Request Format**:
+
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "return_uri": "https://app.example.com/account/security"
+}
+```
+
+**Properties**:
+
+- `access_token`: A valid, non-expired access token belonging to the end-user to enroll. It must have been issued to
+  the calling client.
+- `return_uri`: URI the end-user is redirected to once enrollment completes. It must match one of the calling client's
+  [registered redirect URIs](/technical/configuration/client) — validated with the same OAuth 2.1 redirect-URI rules
+  as the authorization endpoint — to prevent open redirects.
+
+**Response Format**:
+
+`200 OK`:
+
+```json
+{
+  "state": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "redirect_url": "https://auth.example.com/flow/mfa?state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**Errors**:
+
+| Error code | Description |
+|------------|-------------|
+| `client.mfa.enrollment.mfa_disabled` | This authorization server is not configured to support multi-factor authentication, so an enrollment cannot be started. Please contact the support of the application to report this issue. |
+| `client.mfa.enrollment.invalid_access_token` | The access token identifying the end-user is missing, expired, revoked, not associated with an end-user, or was not issued to your client. Obtain a fresh access token for the end-user and try again. |
+
+An invalid `return_uri` — one that does not match the client's registered redirect URIs — is rejected the same way.
+
+**Properties**:
+
+- `state`: Signed token identifying the enrollment [interactive flow](/technical/api/flow#state-management) session.
+- `redirect_url`: URL to navigate the end-user's browser to in order to run the enrollment steps. The `state` is
+  already included in the URL.
+
+The client is responsible for navigating the end-user's browser to `redirect_url`. The endpoint returns JSON rather
+than issuing a `303` redirect because the caller is a client backend holding a bearer token, not the browser itself.
+
+**Important Notes**:
+
+- The MFA-not-enabled check happens up front: if no MFA method is enabled in the server configuration
+  ([`mfa.totp.enabled`](/technical/configuration/authorization#mfa)), the endpoint fails immediately with a `400`
+  error before any enrollment session is created.
+- Enrollment reuses the same steps as the sign-in flow — method selection, then TOTP enrollment. See
+  [How an Interactive Flow Works](/functional/interactive_flow).
+
+**Use Cases**:
+
+- Offer MFA enrollment from an application's account-settings or security screen.
+- Prompt existing users to add a second factor without sending them through a full re-authentication.
+- Drive MFA enrollment from a custom, branded UI.
 
 ---
 
@@ -471,15 +552,6 @@ token is returned only in this response — it cannot be retrieved later.
 
 **Response Format**:
 
-`400 Bad Request` (claim not writable):
-
-```json
-{
-  "error": "invitation.claim_not_writable",
-  "error_description": "The client does not have write access to the claim: custom_role"
-}
-```
-
 `201 Created`:
 
 ```json
@@ -508,6 +580,13 @@ token is returned only in this response — it cannot be retrieved later.
 - `note`: Note, or `null` if none
 - `created_at`: ISO 8601 timestamp (UTC) when the invitation was created
 - `expires_at`: ISO 8601 timestamp (UTC) when the invitation expires
+
+**Errors**:
+
+| Error code | Description |
+|------------|-------------|
+| `invitation.unknown_claim` | The claim `{claim}` does not exist or is not enabled. Please check the available claims and try again. |
+| `invitation.claim_not_writable` | The claim `{claim}` cannot be pre-assigned by this client. The client does not hold the required scopes. |
 
 **Use Cases**:
 
@@ -634,14 +713,11 @@ invitation was not created by this client.
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No invitation found with id: a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
 
 **Properties**:
 
@@ -690,14 +766,12 @@ redeemed. Returns 404 if the invitation was not created by this client. This ope
 }
 ```
 
-`404 Not Found`:
+**Errors**:
 
-```json
-{
-  "error": "not_found",
-  "error_description": "No invitation found with id: a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-}
-```
+| Error code | Description |
+|------------|-------------|
+| `not_found` | The resource you are looking for is not available on this authorization server. |
+| `invitation.cannot_revoke` | The invitation cannot be revoked because it is in status `{status}`; only pending invitations can be revoked. |
 
 **Use Cases**:
 


### PR DESCRIPTION
## Summary

Documents the on-demand MFA enrollment endpoint from sympauthy/sympauthy#280 and aligns the API error documentation with the actual backend implementation.

### New endpoint — `POST /api/v1/client/mfa/enrollment`
- **Dual authentication**: client-credentials bearer token holding the new `users:mfa:write` scope **and** the end-user's access token in the request body (which must have been issued to the calling client).
- `return_uri` validated against the client's registered redirect URIs; JSON `{state, redirect_url}` response (no server 303).
- Added `users:mfa:read` / `users:mfa:write` to the client scope tables (technical + functional).
- Presented functionally as a **"What a client can do"** section on the Client page, with an **"Enrolling MFA on demand"** subsection.

### Error-format correction
The Client and Admin APIs actually return an `ErrorResource` (`status` / `error_code` / `description` / `details`), **not** the OAuth2 `{error, error_description}` shape the docs showed. This PR:
- Rewrites every error block in `client.md` and `admin.md` as an **`error_code` + `description` table** (no JSON), using codes verified against the controllers and `error_messages.properties` (`not_found`, `client.subject_without_provider`, `client.invalid_claim`, `invitation.*`, `user.search.invalid_claim`, `client.mfa.enrollment.*`).
- Updates the **API-design contributing guide** to document the real `ErrorResource` envelope and the `print-details-in-error` gating on `details`.

### Notes
- The two `client.mfa.enrollment.*` errors return HTTP **400** (confirmed).
- Only pre-existing error blocks were reshaped — endpoints that currently document no errors (and several marked "not yet implemented") were left untouched.
- `npm run docs:build` passes (VitePress fails on dead links, so all cross-links/anchors resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)